### PR TITLE
Webpack experiment - fixed karma

### DIFF
--- a/ui/src/main/webapp/karma.conf.js
+++ b/ui/src/main/webapp/karma.conf.js
@@ -34,7 +34,7 @@ module.exports = function (config) {
             noInfo: true
         },
 
-        reporters: ['progress'],
+        reporters: ['progress', 'junit'],
         port: 9876,
         colors: true,
         logLevel: config.LOG_INFO,

--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -49,6 +49,7 @@
     "jquery": "2.1.4",
     "jquery-match-height": "0.7.0",
     "jstree": "^3.3.2",
+    "karma-junit-reporter": "^1.1.0",
     "ng2-file-upload": "^1.1.0",
     "patternfly": "^3.0.0",
     "patternfly-bootstrap-combobox": "1.0.0",

--- a/ui/src/main/webapp/src/app/components/modal-dialog.component.ts
+++ b/ui/src/main/webapp/src/app/components/modal-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from "@angular/core";
 import * as $ from "jquery";
+window['jQuery'] = $; // ugly hack, bootstrap cannot consume jQuery as dependency
 import 'bootstrap';
 
 var modalID = 0;

--- a/ui/src/main/webapp/tests/app/components/modal-dialog.component.spec.ts
+++ b/ui/src/main/webapp/tests/app/components/modal-dialog.component.spec.ts
@@ -2,6 +2,8 @@ import {ComponentFixture, TestBed, async, ComponentFixtureAutoDetect, fakeAsync,
 import {By} from "@angular/platform-browser";
 import {DebugElement, Component, ViewChild} from "@angular/core";
 import {ModalDialogComponent} from "../../../src/app/components/modal-dialog.component";
+import * as $ from 'jquery';
+import 'bootstrap';
 
 let host: ModalDialogHost;
 let hostFixture: ComponentFixture<ModalDialogHost>;

--- a/ui/src/main/webapp/tsconfig.json
+++ b/ui/src/main/webapp/tsconfig.json
@@ -6,8 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "removeComments": false,
-    "noImplicitAny": false,
-    "noEmitHelpers": true
+    "noImplicitAny": false
   },
   "compileOnSave": false,
   "buildOnSave": false,


### PR DESCRIPTION
Now it can run unit tests using `karma start`. It can be also run in watch mode using `karma start --auto-watch --single-run false`

There are 2 failing tests, I'm not sure if it is caused by some mistake in rebasing or some webpack-experiment related issue.

I didn't get to fix that jstree issue.

So right now I see 2 major issues:
1. That problem with jstree
2. Updating maven task

And one nice to have thing:
1. Run karma directly from webpack without using karma start command
